### PR TITLE
remove this.innerHTML and use this.clear()

### DIFF
--- a/qr-code.js
+++ b/qr-code.js
@@ -63,11 +63,11 @@ export default class QRCode extends HTMLElement {
                 this.generateSVG()
             }
             else {
-                this.shadowRoot.innerText = `qr-code: ${this.format} not supported!`
+                this.shadowRoot.textContent = `qr-code: ${this.format} not supported!`
            }
         }
         else {
-            this.shadowRoot.innerText = 'qr-code: no data!'
+            this.shadowRoot.textContent = 'qr-code: no data!'
         }
     }
     generatePNG() {
@@ -77,7 +77,7 @@ export default class QRCode extends HTMLElement {
             this.shadowRoot.appendChild(img)
         }
         catch (e) {
-            this.shadowRoot.innerText = 'qr-code: canvas not supported!'
+            this.shadowRoot.textContent = 'qr-code: canvas not supported!'
         }
     }
     generateHTML() {

--- a/qr-code.js
+++ b/qr-code.js
@@ -11,7 +11,7 @@ export default class QRCode extends HTMLElement {
         Object.keys(QRCode.defaultAttributes).map(this._defineProperty)
     }
     static get defaultAttributes() {
-        return { 
+        return {
             data: null,
             format: 'png',
             modulesize: 5,
@@ -51,6 +51,7 @@ export default class QRCode extends HTMLElement {
         }
     }
     generate() {
+        this.clear()
         if (this.data !== null) {
             if (this.format === 'png') {
                 this.generatePNG()
@@ -62,32 +63,29 @@ export default class QRCode extends HTMLElement {
                 this.generateSVG()
             }
             else {
-                this.shadowRoot.innerHTML = '<div>qr-code: '+ this.format +' not supported!</div>'
-            }
+                this.shadowRoot.innerText = `qr-code: ${this.format} not supported!`
+           }
         }
         else {
-            this.shadowRoot.innerHTML = '<div>qr-code: no data!</div>'
+            this.shadowRoot.innerText = 'qr-code: no data!'
         }
     }
     generatePNG() {
         try {
             let img = document.createElement('img')
             img.src = _QRCode.generatePNG(this.data, this.getOptions())
-            this.clear()
             this.shadowRoot.appendChild(img)
         }
         catch (e) {
-            this.shadowRoot.innerHTML = '<div>qr-code: no canvas support!</div>'
+            this.shadowRoot.innerText = 'qr-code: canvas not supported!'
         }
     }
     generateHTML() {
         let div = _QRCode.generateHTML(this.data, this.getOptions())
-        this.clear()
         this.shadowRoot.appendChild(div)
     }
     generateSVG() {
         let div = _QRCode.generateSVG(this.data, this.getOptions())
-        this.clear()
         this.shadowRoot.appendChild(div)
     }
     clear() {


### PR DESCRIPTION
Hello,

It seems that here: https://github.com/educastellano/qr-code/blob/gh-pages/qr-code.js#L65, the use of `this.innerHTML` could allow attackers to inject arbitrary code in the `format=""` attribute of the `qr-code` element.

To try mitigate this, this PR tries to remove the use of `this.innerHTML`, and to clear the existing DOM with the existing `this.clear()` method.

Let me know if you think that makes sense.