### PR TITLE
shadow dom styling: add css part="{svg,img,table}" for the respective qr-code[format] child

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Attribute       | Options                   | Default             | Description
 `modulesize`    | *int*                     | `5`                 | Size of the modules in *pixels*.
 `margin`        | *int*                     | `4`                 | Margin of the QR code in *modules*.
 
+## CSS `part` styling
+
+To style the shadow DOM children elements created by the `qr-code` web component, it is possible to use their `part` attribute.
+
+```css
+/* for format="svg" */
+qr-code::part(svg) {
+  witdh: 100%;
+}
+/* for format="png" */
+qr-code::part(img) {}
+
+/* for format="html" */
+qr-code::part(table) {}
+```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import 'webcomponent-qr-code'
 <qr-code data="hello world!"></qr-code>
 ```
 
-**Custom element name:**
+**Custom element name**
 
 ```js
 import QRCode from 'webcomponent-qr-code/qr-code'
@@ -47,6 +47,20 @@ customElements.define('myapp-qrcode', QRCode)
 <myapp-qrcode data="hello world!"></myapp-qrcode>
 ```
 
+**Custom styles**
+
+Use the `part` attribute to style shadow DOM elements:
+
+```css
+/* format="png" */
+qr-code::part(img) {}
+
+/* format="html" */
+qr-code::part(table) {}
+
+/* format="svg" */
+qr-code::part(svg) {}
+```
 
 
 ## Options
@@ -57,22 +71,6 @@ Attribute       | Options                   | Default             | Description
 `format`        | `png`, `html`, `svg`      | `png`               | Format of the QR code rendered inside the component.
 `modulesize`    | *int*                     | `5`                 | Size of the modules in *pixels*.
 `margin`        | *int*                     | `4`                 | Margin of the QR code in *modules*.
-
-## CSS `part` styling
-
-To style the shadow DOM children elements created by the `qr-code` web component, it is possible to use their `part` attribute.
-
-```css
-/* for format="svg" */
-qr-code::part(svg) {
-  witdh: 100%;
-}
-/* for format="png" */
-qr-code::part(img) {}
-
-/* for format="html" */
-qr-code::part(table) {}
-```
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ customElements.define('myapp-qrcode', QRCode)
 
 **Custom styles**
 
-Use the `part` attribute to style shadow DOM elements:
+Use the `part` pseudo-element to style shadow DOM elements:
 
 ```css
 /* format="png" */
@@ -82,6 +82,8 @@ Attribute       | Options                   | Default             | Description
 5. Submit a pull request :D
 
 ## Changelog
+* v1.1.0 November 15, 2022
+    * Support for custom styles with the `::part` CSS pseudo-element
 * v1.0.0 July 13, 2018
     * Use new API customElements.define
     * Support for a custom element name

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,43 +4,91 @@
 	<meta charset="UTF-8">
 	<title>&lt;qr-code&gt;</title>
 	<style>
+
+		* {
+			box-sizing: border-box;
+		}
+
 		body {
-			background: #eeeeee;
+			margin: 0;
+			padding: 32px;
+			height: 100vh;
+			background: #eee;
+			font-family: Avenir;
 		}
-		.content {
-			padding: 50px;
-			margin-left: 200px;
+
+		hr {
+			margin: 32px 0;
 		}
-		#data {
+		
+		.row0 {
+			display: flex;
+			justify-content: center;
+		}
+
+		.qr input {
 			font-size: 1.2em;
-			width: 300px
+			width: 300px;
+			padding: 4px 8px;
 		}
-		.theshow {
-			float: left;
-		}
-		label {
+
+		.options label {
 			display: inline-block;
 			width: 150px;
 			text-align: right;
 		}
-		#scalable {
+
+		.options input,
+		.options select {
+			margin: 4px 4px;
+			padding: 2px 4px;
+			font-size: 15px;
+		}
+
+		.options #scalable {
 			display: none;
 		}
+
+		/* custom styles	*/
+
+		.row1 {
+			display: flex;
+			flex-direction: column;
+		}
+
+		.row1 .qr-list {
+			display: flex;
+			justify-content: space-around;
+			flex-wrap: wrap;
+		}
+
+		.row1 .qr-list qr-code:first-child::part(svg) {
+			border-radius: 30px;
+		}
+
+		.row1 .qr-list qr-code:nth-child(2)::part(svg) {
+			transform: scale(1.2) rotate(-10deg);
+		}
+
+		.row1 .qr-list qr-code:last-child::part(svg) {
+			border: 4px solid tomato;
+		}
+
+
 	</style>
 </head>
 <body>
-	<div class="content">
-		<div class="theshow">
+	<div class="row0">
+		<div class="qr">
 			<input
-				id="data"
 				type="text"
-				value="bla bla blaaaaaaaaaahhh"
+				value="Data encoded in the QR code..."
 				oninput="document.querySelector('qr-code').data = this.value"
 				autofocus
 			/>
 			<br><br>
 			<!-- Using the Web Component -->
-			<qr-code data="bla bla blaaaaaaaaaahhh"></qr-code>
+			<qr-code data="Data encoded in the QR code..." format="png"></qr-code>
 		</div>
 		<div class="options">
 			<label for="format">Format</label>
@@ -75,6 +123,15 @@
 				max=30
 				onkeypress="return event.charCode >= 48 && event.charCode <= 57"
 			/>
+		</div>
+	</div>
+	<hr />
+	<div class="row1">
+		<h2>Custom styles</h2>
+		<div class="qr-list">
+			<qr-code data="Tomato QR code" format="svg"></qr-code>
+			<qr-code data="Red QR code" format="svg"></qr-code>
+			<qr-code data="Red QR code" format="svg"></qr-code>
 		</div>
 	</div>
 	<!-- Polyfill and Web Component -->

--- a/qr-code.js
+++ b/qr-code.js
@@ -93,8 +93,9 @@ export default class QRCode extends HTMLElement {
 
   generateHTML() {
     const div = _QRCode.generateHTML(this.data, this.getOptions())
-    document.querySelector('table').setAttribute('part', 'table')
-    this.shadowRoot.appendChild(div)
+    const table = div.firstChild
+    table.setAttribute('part', 'table')
+    this.shadowRoot.appendChild(table)
   }
 
   generateSVG() {

--- a/qr-code.js
+++ b/qr-code.js
@@ -87,17 +87,20 @@ export default class QRCode extends HTMLElement {
   generatePNG() {
     const img = document.createElement('img')
     img.src = _QRCode.generatePNG(this.data, this.getOptions())
+    img.setAttribute('part', 'img')
     this.shadowRoot.appendChild(img)
   }
 
   generateHTML() {
     const div = _QRCode.generateHTML(this.data, this.getOptions())
+    document.querySelector('table').setAttribute('part', 'table')
     this.shadowRoot.appendChild(div)
   }
 
   generateSVG() {
-    const div = _QRCode.generateSVG(this.data, this.getOptions())
-    this.shadowRoot.appendChild(div)
+    const svg = _QRCode.generateSVG(this.data, this.getOptions())
+    svg.setAttribute('part', 'svg')
+    this.shadowRoot.appendChild(svg)
   }
 
   clear() {


### PR DESCRIPTION
In order to be able to style the shadow DOM element, I've been doing a few different hacks, such as injecting `<style></style>` tag in the shadow dom of all `qr-code` on my sites.

But recently I've tried extending your code with css parts https://gitlab.com/sctlib/qr-code-utils/-/blob/main/src/qr-code.js#L10, and I think it works very well.

Do you think this could be a useful addition?

Thanks in advance.